### PR TITLE
find -> upper_bound

### DIFF
--- a/LIS.cpp
+++ b/LIS.cpp
@@ -14,11 +14,8 @@ int main() {
 	{
 		cin>>x;
 		s.insert(x);
-		it = s.find(x);
-		it++;
-		if(it!=s.end())
-			s.erase(it);
-		
+		it=s.upper_bound(x);
+		if(it!=s.end())s.erase(it);
 	}
 	cout<<s.size();
 	return 0;


### PR DESCRIPTION
find() doesn't guarantee that the iterator will be placed at the end of all the x's in the set. e.g., If the set contains: 1 2 2 3, then iterator could point to first or second 2 if find() is used. Upper_bound will automatically put the iterator in the desired place :)
